### PR TITLE
Chocolatey package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ nuget/
 packages/
 artifacts/
 script.sql
+*.nupkg

--- a/choco.ps1
+++ b/choco.ps1
@@ -1,0 +1,12 @@
+cd chocolatey
+
+cpack
+
+#nuget.exe setApiKey YOURS-VERY-OWN-API-KEY -Source http://chocolatey.org/
+gci *.nupkg | %{
+    Write-Host Push $_
+    cpush $_
+    rm $_
+}
+
+cd ..

--- a/chocolatey/SuperBenchmarker.nuspec
+++ b/chocolatey/SuperBenchmarker.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>SuperBenchmarker</id>
+    <version>0.0.1</version>
+    <title>SuperBenchmarker</title>
+    <authors>Ali Kheyrollahi</authors>
+    <owners>Ali Kheyrollahi</owners>
+    <projectUrl>https://github.com/aliostad/SuperBenchmarker</projectUrl>
+    <!-- <iconUrl></iconUrl> -->
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>   
+    <description>Superbenchmarker is a load generator command-line tool for testing websites and HTTP APIs and meant to become Apache Benchmark (ab.exe) on steriod.</description> 
+    <summary>Load generator command-line tool for testing websites and HTTP APIs</summary>
+    <tags>superbenchmarker sb</tags>    
+  </metadata>
+  <files>
+      <file src="..\download\*" target="tools" />
+    </files>
+</package>


### PR DESCRIPTION
Hello,

I added chocolatey package, so you can publish it to chocolatey.org. Small instruction:
1. Source nuspec is located in chocolatey/SuperBenchmarker.nuspec, you can change version, description, etc.
2. To build package (this is optional, if you would like to test it) you need chocolatey installed (oneliner), and after this you can use command cpack
3. To publish to chocolatey.org, first you need request API key and apply it with
    nuget.exe setApiKey YOURS-VERY-OWN-API-KEY -Source http://chocolatey.org/
4. Then run choco.ps1, this will pack package and then push it to the http://chocolatey.org/

If you want, I can do this for you. I will add you as owner of the package.

Main benefit of having SuperBenchmarker on Chocolatey is super simple installation, assuming you have Chocolatey installed:

```
cinst SuperBenchmarker 
```

This will actually download package, unpack and install it to your PATH, so one will be able to use sb form anywhere.
Chocolatey  also can update package, uninstall them.
